### PR TITLE
SecurityCriticalBackwardsCompatibility

### DIFF
--- a/Tools/AssemblyInfo.cs
+++ b/Tools/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using System.Security;
 
 [assembly: CLSCompliant(true)]
-[assembly: SecurityTransparent]
+#if NET
+[assembly: System.Security.SecurityTransparent]
+#endif


### PR DESCRIPTION
- Excluded SecurityTransparent attribute from NetStandard builds as it is necessary for Net Framework runtimes

See discussion in https://github.com/Dixin/EnterpriseLibrary.TransientFaultHandling.Core/issues/5